### PR TITLE
docs: mkdocs의 use_directory_urls 활성화

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,8 @@ theme:
       primary: deep orange
       accent: lime
 
+use_directory_urls: false
+
 nav:
   # - Home: index.md
   - Code of Conduct (English):


### PR DESCRIPTION
https://github.com/pythonkr/pycon-code-of-conduct/pull/6 변경 사항에서 `use_directory_urls` 옵션이 누락되어, 기존 외부 링크에서 접근할 수 없는 문제가 있어 이를 다시 추가합니다.
